### PR TITLE
Release v2.2.8 — WordPress 6.9.1 compatibility

### DIFF
--- a/languages/style-manager.pot
+++ b/languages/style-manager.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0 or later..
 msgid ""
 msgstr ""
-"Project-Id-Version: Style Manager 2.2.7\n"
+"Project-Id-Version: Style Manager 2.2.8\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/style-manager\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: pixelgrade, vlad.olaru, babbardel, razvanonofrei, gorby31
 Tags: design, customizer, fonts, colors, gutenberg, font palettes, color palettes, global styles
 Requires at least: 5.5.0
-Tested up to: 6.0
-Stable tag: 2.2.7
+Tested up to: 6.9.1
+Stable tag: 2.2.8
 Requires PHP: 7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -53,6 +53,18 @@ To enable them simply go to Dashboard -> Appearance -> Style Manager and check "
 * Default [image](https://unsplash.com/photos/OgM4RKdr2kY) for Style Manager Color Palette control - License: [Unsplash](https://unsplash.com/license)
 
 == Changelog ==
+
+= 2.2.8 =
+* 2026-02-09
+* Upgrade Carbon Fields library to version 3.6.9 for WordPress 6.2+ compatibility (React 18).
+* Fix Settings page not rendering fields on WordPress 6.2+.
+* Fix PHP 8.2 ReturnTypeWillChange deprecation notices from Carbon Fields.
+* Security: sanitize $_SERVER['REQUEST_URI'] in exception message.
+* Security: replace $_SERVER['PHP_SELF'] with global $pagenow.
+* Security: add capability check to AJAX migration handler.
+* Security: cast sm_site_color_variation to integer in JS output.
+* Security: escape RadioImage control colors, labels, and data attributes.
+* Tested with WordPress 6.9.1.
 
 = 2.2.7 =
 * 2022-06-16

--- a/style-manager.php
+++ b/style-manager.php
@@ -7,7 +7,7 @@
  * Plugin URI:  https://github.com/pixelgrade/style-manager
  * Update URI:  false
  * Description: Auto-magical system to style your entire WordPress site.
- * Version: 2.2.7
+ * Version: 2.2.8
  * Author: Pixelgrade
  * Author URI: https://pixelgrade.com
  * Author Email: contact@pixelgrade.com
@@ -16,7 +16,7 @@
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path: /languages/
  * Requires at least: 5.5.0
- * Tested up to: 6.0
+ * Tested up to: 6.9.1
  * Requires PHP: 7.1
  * GitHub Plugin URI: pixelgrade/style-manager
  * Release Asset: true
@@ -36,7 +36,7 @@ if ( ! \defined( 'ABSPATH' ) ) {
  *
  * @var string
  */
-const VERSION        = '2.2.7';
+const VERSION        = '2.2.8';
 
 /**
  * Plugin required minimal PHP version.


### PR DESCRIPTION
## Summary

- Bumps plugin version from 2.2.7 to 2.2.8
- Updates `Tested up to` from 6.0 to 6.9.1
- Adds changelog entry covering CF upgrade (#42) and security fixes

Closes #44

## Changelog (2.2.8)

- Upgrade Carbon Fields library to version 3.6.9 for WordPress 6.2+ compatibility (React 18)
- Fix Settings page not rendering fields on WordPress 6.2+
- Fix PHP 8.2 ReturnTypeWillChange deprecation notices from Carbon Fields
- Security: sanitize `$_SERVER['REQUEST_URI']` in exception message
- Security: replace `$_SERVER['PHP_SELF']` with global `$pagenow`
- Security: add capability check to AJAX migration handler
- Security: cast `sm_site_color_variation` to integer in JS output
- Security: escape RadioImage control colors, labels, and data attributes
- Tested with WordPress 6.9.1

## Test plan

- [ ] Verify plugin header shows version 2.2.8
- [ ] Verify readme.txt stable tag is 2.2.8
- [ ] Verify `Tested up to` is 6.9.1 in both files
- [ ] Verify Settings page works on WP 6.9.1
- [ ] Verify Customizer works on WP 6.9.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)